### PR TITLE
docs: explain deployment and technology stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,33 @@ Dashloom Community normalizes operational signals, calculates deterministic metr
 - English and Simplified Chinese dashboard navigation, workspace-level locale preferences, and focused tabbed workflows.
 - Connector and Agent Skill SDKs, reviewed community extensions, audit history, and portable evidence export.
 
-Cloudflare Workers, Vercel, AWS, D1 application storage, and Supabase PostgreSQL are deployment or storage choices—not business data sources. The Dashboard catalog only lists systems that provide product, acquisition, search, revenue, or explicitly imported business evidence.
-
 Dashloom Community is a standalone open-source product. It has no source, package, runtime, database, deployment, Git, or build dependency on the private Dashloom Cloud repository.
+
+## Deployment methods and data sources are separate concerns
+
+Dashloom Community runs on infrastructure you control. Choose a deployment target and application database first; after signing in, connect only the business sources whose evidence you need. Deploying on a platform does not automatically make that platform a Dashloom data source.
+
+### Deployment paths
+
+| Path | Application runtime | Application database |
+| --- | --- | --- |
+| Cloudflare-native | Vinext on Cloudflare Workers | Native Cloudflare D1 binding |
+| Vercel | Next.js on Node.js | Cloudflare Remote D1 or Supabase PostgreSQL |
+| AWS | Next.js on Node.js, including AWS Amplify Hosting | Cloudflare Remote D1 or Supabase PostgreSQL |
+
+### Open-source technology stack
+
+| Area | Technologies | Role in Dashloom |
+| --- | --- | --- |
+| Deployment | Cloudflare Workers, Vercel, AWS | Hosts the Community application |
+| Storage | Cloudflare D1, Supabase PostgreSQL | Stores authentication, workspace configuration, normalized evidence, Agent state, reports, schedules, and audit history |
+| Application | Next.js, React, Node.js | Provides the server runtime and product interface |
+| Development | TypeScript, Tailwind CSS | Provides typed application code and the UI styling system |
+| Optional Cloudflare analytics | Cloudflare R2 | Supplies bounded operational metrics through the retained compatibility connector; it is not an application storage backend |
+
+The Dashboard business-source catalog covers Google Analytics, Google Search Console, Bing Webmaster Tools, Cloudflare D1 business data, Stripe, Lemon Squeezy, Creem, Polar, Paddle, and custom ingestion. Deployment platforms and application databases remain separate from this catalog.
+
+See the [Vercel and AWS deployment guide](docs/deployment-next.md) and [Cloudflare deployment guide](docs/cloudflare-setup.md) for setup details.
 
 ## Product tour
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -21,9 +21,33 @@ Dashloom 会标准化运营数据、计算确定性指标，再让专用 Agent �
 - 中英文控制台导航、工作空间级语言偏好，以及按任务分组的标签页工作流。
 - Connector/Agent Skill SDK、社区扩展审核、审计历史和可迁移证据导出。
 
-Cloudflare Workers、Vercel、AWS、作为应用存储的 D1 和 Supabase PostgreSQL 都是部署或存储选项，不是业务数据源。控制台数据源目录只展示产品、获客、搜索、收入或明确导入的业务证据。
-
 Dashloom Community 是独立的开源产品，与私有 Dashloom Cloud 仓库不存在源码、Package、运行时、数据库、部署、Git 或构建依赖。
+
+## 部署方式与数据源是两类概念
+
+Dashloom Community 运行在你控制的基础设施中。先选择部署目标和应用数据库，登录后再按实际需要连接业务数据源。部署到某个平台，并不会自动把该平台变成 Dashloom 数据源。
+
+### 部署路径
+
+| 路径 | 应用运行时 | 应用数据库 |
+| --- | --- | --- |
+| Cloudflare 原生 | Vinext 运行于 Cloudflare Workers | 原生 Cloudflare D1 Binding |
+| Vercel | Next.js 运行于 Node.js | Cloudflare Remote D1 或 Supabase PostgreSQL |
+| AWS | Next.js 运行于 Node.js，包括 AWS Amplify Hosting | Cloudflare Remote D1 或 Supabase PostgreSQL |
+
+### 开源技术栈
+
+| 分类 | 技术 | 在 Dashloom 中的作用 |
+| --- | --- | --- |
+| 部署 | Cloudflare Workers、Vercel、AWS | 承载 Community 应用 |
+| 存储 | Cloudflare D1、Supabase PostgreSQL | 保存认证、工作空间配置、标准化证据、Agent 状态、报告、计划和审计历史 |
+| 应用 | Next.js、React、Node.js | 提供服务端运行时和产品界面 |
+| 开发 | TypeScript、Tailwind CSS | 提供类型安全的应用代码和界面样式系统 |
+| 可选 Cloudflare 分析 | Cloudflare R2 | 通过保留的兼容连接器提供有界运维指标，不作为应用存储后端 |
+
+控制台业务数据源目录包括 Google Analytics、Google Search Console、Bing Webmaster Tools、Cloudflare D1 业务数据、Stripe、Lemon Squeezy、Creem、Polar、Paddle 和自定义数据接入。部署平台和应用数据库与此目录保持分离。
+
+配置方式见 [Vercel 和 AWS 部署指南](docs/deployment-next.zh-CN.md)及 [Cloudflare 部署指南](docs/cloudflare-setup.zh-CN.md)。
 
 ## 产品功能
 


### PR DESCRIPTION
Adds matching English and Chinese README sections for deployment paths, the open-source stack, and the boundary between hosting, application storage, and business data sources. Clarifies that R2 is an optional compatibility analytics connector rather than an application storage backend.