### PR TITLE
docs: update open-source deployment guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Dashloom Community runs on infrastructure you control. Choose a deployment targe
 
 The Dashboard business-source catalog covers Google Analytics, Google Search Console, Bing Webmaster Tools, Cloudflare D1 business data, Stripe, Lemon Squeezy, Creem, Polar, Paddle, and custom ingestion. Deployment platforms and application databases remain separate from this catalog.
 
-See the [Vercel and AWS deployment guide](docs/deployment-next.md) and [Cloudflare deployment guide](docs/cloudflare-setup.md) for setup details.
+See the [Cloudflare deployment guide](docs/deployment-cloudflare.md) and [Vercel and AWS deployment guide](docs/deployment-next.md) for setup details.
 
 ## Product tour
 
@@ -242,6 +242,8 @@ Connector and model keys are entered through authenticated product forms. Do not
 
 ## Production deployment on Cloudflare
 
+For a complete step-by-step setup, including database creation, language selection, secrets, remote migration verification, deployment, rollback, and troubleshooting, see the [Cloudflare deployment guide](docs/deployment-cloudflare.md).
+
 1. Create a D1 database and replace the placeholder database name and ID in `wrangler.jsonc`. Set `DASHLOOM_DEFAULT_LOCALE` under `vars` to `en` or `zh-CN`.
 2. Configure production secrets with `npx wrangler secret put <NAME>`; never copy local secrets into source control.
 3. Apply migrations to the intended remote database:
@@ -300,6 +302,7 @@ npm run eval:agent
 ## Documentation
 
 - [Architecture and security boundaries](docs/architecture.md)
+- [Cloudflare deployment](docs/deployment-cloudflare.md)
 - [Vercel and AWS deployment](docs/deployment-next.md)
 - [Backup and recovery](docs/backup-and-recovery.md)
 - [First-value path](docs/first-value-path.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -61,7 +61,7 @@ Dashloom Community 运行在你控制的基础设施中。先选择部署目标�
 
 控制台业务数据源目录包括 Google Analytics、Google Search Console、Bing Webmaster Tools、Cloudflare D1 业务数据、Stripe、Lemon Squeezy、Creem、Polar、Paddle 和自定义数据接入。部署平台和应用数据库与此目录保持分离。
 
-配置方式见 [Vercel 和 AWS 部署指南](docs/deployment-next.zh-CN.md)及 [Cloudflare 部署指南](docs/cloudflare-setup.zh-CN.md)。
+配置方式见 [Cloudflare 部署指南](docs/deployment-cloudflare.zh-CN.md)及 [Vercel 和 AWS 部署指南](docs/deployment-next.zh-CN.md)。
 
 ## 产品功能
 
@@ -242,6 +242,8 @@ Community 的 Agent 只使用 BYOK，不需要 Dashloom 托管模型额度或订
 
 ## 部署到 Cloudflare
 
+完整的数据库创建、语言选择、Secret、远程 Migration 核验、发布、回滚和故障处理步骤见 [Cloudflare 部署指南](docs/deployment-cloudflare.zh-CN.md)。
+
 1. 创建 D1 数据库，并替换 `wrangler.jsonc` 中的占位数据库名称与 ID；同时在 `vars` 中把 `DASHLOOM_DEFAULT_LOCALE` 设为 `en` 或 `zh-CN`。
 2. 使用 `npx wrangler secret put <NAME>` 配置生产 Secret；不要把本地 Secret 写入源码。
 3. 把迁移应用到目标远程数据库：
@@ -300,6 +302,7 @@ npm run eval:agent
 ## 延伸文档
 
 - [架构与安全边界](docs/architecture.zh-CN.md)
+- [Cloudflare 部署](docs/deployment-cloudflare.zh-CN.md)
 - [Vercel 和 AWS 部署](docs/deployment-next.zh-CN.md)
 - [备份与恢复](docs/backup-and-recovery.zh-CN.md)
 - [首次价值路径](docs/first-value-path.zh-CN.md)

--- a/docs/deployment-cloudflare.md
+++ b/docs/deployment-cloudflare.md
@@ -1,0 +1,142 @@
+# Deploy Dashloom Community on Cloudflare
+
+This path runs Dashloom with Vinext on Cloudflare Workers and stores the complete application state in a native D1 binding named `DB`. The scheduled handler in `worker.ts` runs every 15 minutes through the committed `wrangler.jsonc` trigger.
+
+Use a fresh Community-only D1 database. Do not point this repository at a Dashloom Cloud or pre-release database.
+
+## Prerequisites
+
+- Node.js 22.13 or newer and npm 10 or newer
+- A Cloudflare account with permission to create Workers and D1 databases
+- Wrangler authentication (`npx wrangler login`) or an equivalent CI API token
+- A public application origin for `BETTER_AUTH_URL`
+
+Clone and install the project:
+
+```bash
+git clone https://github.com/dashloom-dev/dashloom.git
+cd dashloom
+npm ci
+```
+
+## 1. Create and bind the production D1 database
+
+Create a database with a name you control:
+
+```bash
+npx wrangler d1 create dashloom-production
+```
+
+Copy the returned database name and UUID into the existing `d1_databases` entry in `wrangler.jsonc`. Keep the binding name and migrations directory unchanged:
+
+```json
+{
+  "binding": "DB",
+  "database_name": "dashloom-production",
+  "database_id": "YOUR-D1-DATABASE-UUID",
+  "migrations_dir": "./drizzle"
+}
+```
+
+Confirm that Wrangler resolves the intended production database before applying anything:
+
+```bash
+npx wrangler d1 info dashloom-production --json
+```
+
+The reported UUID must match `database_id` in `wrangler.jsonc`.
+
+## 2. Choose the deployment language
+
+Set the non-secret `DASHLOOM_DEFAULT_LOCALE` value under `vars` in `wrangler.jsonc`:
+
+```json
+"vars": {
+  "DASHLOOM_DEFAULT_LOCALE": "en"
+}
+```
+
+Use `en` for English or `zh-CN` for Simplified Chinese. This controls the initial authentication and recovery-email language and the locale assigned to newly created workspaces. Workspace owners can change their language later; changing this deployment value does not overwrite existing workspaces.
+
+## 3. Configure production secrets
+
+Generate separate random values for authentication, credential encryption, and cron authentication. Then save them with Wrangler:
+
+```bash
+npx wrangler secret put BETTER_AUTH_SECRET
+npx wrangler secret put BETTER_AUTH_URL
+npx wrangler secret put CREDENTIALS_ENCRYPTION_KEY
+npx wrangler secret put REPORT_CRON_SECRET
+```
+
+`BETTER_AUTH_URL` must be the final HTTPS origin, for example `https://dashloom.example.com`. `BETTER_AUTH_SECRET` and `CREDENTIALS_ENCRYPTION_KEY` must each be at least 32 characters and must not reuse the same value.
+
+Add the following only when the feature is enabled:
+
+```bash
+npx wrangler secret put GOOGLE_OAUTH_CLIENT_ID
+npx wrangler secret put GOOGLE_OAUTH_CLIENT_SECRET
+npx wrangler secret put AUTH_EMAIL_WEBHOOK_URL
+npx wrangler secret put AUTH_EMAIL_WEBHOOK_SECRET
+```
+
+Keep real secrets out of `.dev.vars`, `wrangler.jsonc`, Git history, and `NEXT_PUBLIC_*` variables. Set `AUTH_REQUIRE_EMAIL_VERIFICATION=true` only after the production email relay has been tested.
+
+## 4. Apply and verify remote migrations
+
+List the pending migrations against the exact production database, apply them, and list again:
+
+```bash
+npx wrangler d1 migrations list dashloom-production --remote
+npx wrangler d1 migrations apply dashloom-production --remote
+npx wrangler d1 migrations list dashloom-production --remote
+```
+
+The final list must show no pending migration. Then query that same remote database and confirm the application tables exist:
+
+```bash
+npx wrangler d1 execute dashloom-production --remote --command "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('workspaces','workspace_members','products','metric_points','analysis_runs','reports') ORDER BY name;"
+```
+
+A migration file in `drizzle/` is only an input. Production migration work is complete only after the intended database UUID is confirmed, migrations are applied remotely, no migration remains pending, and critical tables are present.
+
+## 5. Build and deploy
+
+Validate the Worker bundle before publishing:
+
+```bash
+npm run typecheck
+npm test
+npm run build
+npx wrangler deploy --dry-run
+npx wrangler deploy
+```
+
+The committed Cron trigger runs `worker.ts` every 15 minutes, so no separate scheduler is required on this path. After the first deployment, attach the custom domain if needed and update `BETTER_AUTH_URL` whenever the canonical origin changes.
+
+## 6. Verify the production deployment
+
+Test against the deployed origin:
+
+1. Create or sign in to an account and verify the selected deployment language.
+2. Confirm a new workspace is created in that language and that workspace switching remains isolated.
+3. Add one product and run one connector synchronization.
+4. Add an OpenAI-compatible BYOK model and run one cited Agent analysis.
+5. Create a due synchronization or report schedule and confirm the Worker Cron records its execution.
+6. Test export and password recovery before enabling mandatory email verification.
+
+## Upgrades and rollback
+
+Before a risky upgrade, back up the intended D1 database and record a Time Travel bookmark as described in the [backup and recovery guide](backup-and-recovery.md). Apply new migrations before shifting traffic to the new Worker.
+
+If application verification fails, redeploy the previous Worker version. Do not reverse a database migration by deleting tables or editing migration history. Restore the database only from an approved backup or Time Travel bookmark, then re-run migration and schema verification.
+
+## Troubleshooting
+
+- **`DB` binding is unavailable:** keep the binding name exactly `DB` and verify the database UUID in `wrangler.jsonc`.
+- **Authentication redirects to the wrong host:** update `BETTER_AUTH_URL` to the final HTTPS origin and redeploy.
+- **The UI starts in the wrong language:** use exactly `en` or `zh-CN` for `DASHLOOM_DEFAULT_LOCALE`; existing workspace preferences are intentionally preserved.
+- **Scheduled work does not run:** confirm the deployed Worker has the Cron trigger and inspect the automation ledger for task-level failures.
+- **A table is missing after deployment:** stop traffic-changing work, verify the database UUID, re-run the remote migration list, and apply only the repository migration set.
+
+For Cloudflare analytics as a business data source, use the separate [Cloudflare connector compatibility guide](cloudflare-setup.md). Deploying Dashloom on Cloudflare does not automatically connect Cloudflare analytics.

--- a/docs/deployment-cloudflare.zh-CN.md
+++ b/docs/deployment-cloudflare.zh-CN.md
@@ -1,0 +1,142 @@
+# 在 Cloudflare 部署 Dashloom Community
+
+这条路径使用 Vinext 将 Dashloom 运行在 Cloudflare Workers，并通过名为 `DB` 的原生 D1 Binding 保存完整应用状态。`worker.ts` 的 Scheduled Handler 会按照仓库中的 `wrangler.jsonc` 每 15 分钟运行一次。
+
+请创建仅供 Community 使用的新 D1 数据库，不要把本仓库连接到 Dashloom Cloud 或预发布版本的数据库。
+
+## 准备条件
+
+- Node.js 22.13 或更高版本、npm 10 或更高版本
+- 具备 Workers 和 D1 创建权限的 Cloudflare 账号
+- Wrangler 登录状态（`npx wrangler login`）或等效的 CI API Token
+- 用于 `BETTER_AUTH_URL` 的公开应用域名
+
+克隆并安装项目：
+
+```bash
+git clone https://github.com/dashloom-dev/dashloom.git
+cd dashloom
+npm ci
+```
+
+## 1. 创建并绑定生产 D1 数据库
+
+创建一个由你管理的数据库：
+
+```bash
+npx wrangler d1 create dashloom-production
+```
+
+把返回的数据库名称和 UUID 填入 `wrangler.jsonc` 现有的 `d1_databases` 配置，并保持 Binding 名称和 Migration 目录不变：
+
+```json
+{
+  "binding": "DB",
+  "database_name": "dashloom-production",
+  "database_id": "YOUR-D1-DATABASE-UUID",
+  "migrations_dir": "./drizzle"
+}
+```
+
+执行任何生产迁移前，先确认 Wrangler 解析到的是目标数据库：
+
+```bash
+npx wrangler d1 info dashloom-production --json
+```
+
+输出的 UUID 必须与 `wrangler.jsonc` 中的 `database_id` 一致。
+
+## 2. 选择部署语言
+
+在 `wrangler.jsonc` 的 `vars` 中设置非 Secret 变量 `DASHLOOM_DEFAULT_LOCALE`：
+
+```json
+"vars": {
+  "DASHLOOM_DEFAULT_LOCALE": "zh-CN"
+}
+```
+
+使用 `en` 选择英文，使用 `zh-CN` 选择简体中文。它决定登录与找回邮件的初始语言，以及新建工作空间的默认语言。工作空间 Owner 之后仍可切换语言；修改部署变量不会覆盖已有工作空间。
+
+## 3. 配置生产 Secret
+
+为认证、凭证加密和 Cron 认证分别生成独立随机值，然后使用 Wrangler 保存：
+
+```bash
+npx wrangler secret put BETTER_AUTH_SECRET
+npx wrangler secret put BETTER_AUTH_URL
+npx wrangler secret put CREDENTIALS_ENCRYPTION_KEY
+npx wrangler secret put REPORT_CRON_SECRET
+```
+
+`BETTER_AUTH_URL` 必须是最终 HTTPS Origin，例如 `https://dashloom.example.com`。`BETTER_AUTH_SECRET` 与 `CREDENTIALS_ENCRYPTION_KEY` 都必须至少 32 个字符，并且不能复用同一个值。
+
+只在启用对应功能时添加以下 Secret：
+
+```bash
+npx wrangler secret put GOOGLE_OAUTH_CLIENT_ID
+npx wrangler secret put GOOGLE_OAUTH_CLIENT_SECRET
+npx wrangler secret put AUTH_EMAIL_WEBHOOK_URL
+npx wrangler secret put AUTH_EMAIL_WEBHOOK_SECRET
+```
+
+不要把真实 Secret 写入 `.dev.vars`、`wrangler.jsonc`、Git 历史或任何 `NEXT_PUBLIC_*` 变量。只有在生产邮件中继测试通过后，才设置 `AUTH_REQUIRE_EMAIL_VERIFICATION=true`。
+
+## 4. 应用并核验远程 Migration
+
+对准确的生产数据库先检查待执行 Migration，再应用并重新检查：
+
+```bash
+npx wrangler d1 migrations list dashloom-production --remote
+npx wrangler d1 migrations apply dashloom-production --remote
+npx wrangler d1 migrations list dashloom-production --remote
+```
+
+最终结果必须没有待执行 Migration。随后查询同一个远程数据库，确认关键应用表存在：
+
+```bash
+npx wrangler d1 execute dashloom-production --remote --command "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('workspaces','workspace_members','products','metric_points','analysis_runs','reports') ORDER BY name;"
+```
+
+`drizzle/` 中存在 Migration 文件只代表迁移输入已经打包。只有确认目标数据库 UUID、远程应用全部 Migration、没有待执行项且关键表存在后，生产迁移才算完成。
+
+## 5. 构建并部署
+
+发布前验证 Worker Bundle：
+
+```bash
+npm run typecheck
+npm test
+npm run build
+npx wrangler deploy --dry-run
+npx wrangler deploy
+```
+
+仓库内的 Cron Trigger 会让 `worker.ts` 每 15 分钟运行，因此这条路径不需要额外调度器。首次部署后可以绑定自定义域名；标准 Origin 发生变化时，必须同步更新 `BETTER_AUTH_URL`。
+
+## 6. 验证生产部署
+
+在部署域名完成以下检查：
+
+1. 注册或登录账号，并确认使用所选部署语言。
+2. 确认新工作空间使用该语言，且工作空间之间仍保持隔离。
+3. 添加一个产品并完成一次连接器同步。
+4. 添加 OpenAI 兼容的 BYOK 模型，并运行一次带证据引用的 Agent 分析。
+5. 创建到期的同步或报告计划，确认 Worker Cron 记录了本次执行。
+6. 在启用强制邮件验证前测试导出和密码找回。
+
+## 升级与回滚
+
+高风险升级前，按照[备份与恢复指南](backup-and-recovery.zh-CN.md)备份目标 D1，并记录 Time Travel Bookmark。切换流量到新版 Worker 前先应用新 Migration。
+
+如果应用核验失败，重新部署上一版 Worker。不要通过删除表或修改 Migration 历史来反向迁移数据库。只有使用经过确认的备份或 Time Travel Bookmark 恢复数据库后，才能重新执行 Migration 与 Schema 核验。
+
+## 常见问题
+
+- **找不到 `DB` Binding：**Binding 名称必须严格保持为 `DB`，并检查 `wrangler.jsonc` 中的数据库 UUID。
+- **认证跳转到错误域名：**把 `BETTER_AUTH_URL` 更新为最终 HTTPS Origin 后重新部署。
+- **界面初始语言不正确：**`DASHLOOM_DEFAULT_LOCALE` 只能使用 `en` 或 `zh-CN`；已有工作空间偏好不会被覆盖。
+- **定时任务没有运行：**确认已部署的 Worker 包含 Cron Trigger，并在自动化台账中检查任务级失败。
+- **部署后缺少数据表：**停止继续切换流量，核对数据库 UUID，重新检查远程 Migration，并且只应用仓库提供的迁移集合。
+
+如需把 Cloudflare 分析数据作为业务数据源接入，请阅读独立的 [Cloudflare 连接器兼容指南](cloudflare-setup.zh-CN.md)。把 Dashloom 部署在 Cloudflare 上不会自动连接 Cloudflare 分析数据。

--- a/docs/deployment-next.md
+++ b/docs/deployment-next.md
@@ -8,6 +8,17 @@ Dashloom Community has three real runtime paths:
 
 Cloudflare Workers, Vercel, and AWS are deployment targets. They are not business data sources and do not appear in the Dashboard data-source catalog.
 
+For the native Worker path, use the [Cloudflare deployment guide](deployment-cloudflare.md).
+
+## Prerequisites
+
+- Node.js 22.13 or newer and npm 10 or newer
+- A Vercel project, AWS Amplify Hosting app, or another compatible Node.js host
+- One fresh Community-only Remote D1 database or Supabase project
+- A public HTTPS origin for authentication callbacks
+
+Run `npm ci` and `npm test` locally before connecting the repository to the host.
+
 ## Required environment variables
 
 Copy `node-runtime.env.example` into the environment-variable settings for the selected platform. Always configure the authentication, credential-encryption, and cron secrets. Then choose exactly one storage backend:
@@ -39,7 +50,19 @@ Send `Authorization: Bearer <REPORT_CRON_SECRET>` and keep the same independent 
 
 Apply the migration set for the chosen backend before starting the deployment. A successful application build does not apply production schema changes.
 
-For D1, use Wrangler and verify the intended remote database has no pending migration. For Supabase, copy the database connection string from the Supabase database settings, set `SUPABASE_DATABASE_URL` only in your secure shell or CI secret store, then run:
+For D1, first confirm the production database name and UUID. The returned UUID must match `CLOUDFLARE_D1_DATABASE_ID`. List the migration state, apply the repository migrations, list again, and query critical tables in that same database:
+
+```bash
+npx wrangler d1 info dashloom-production --json
+npx wrangler d1 migrations list dashloom-production --remote
+npx wrangler d1 migrations apply dashloom-production --remote
+npx wrangler d1 migrations list dashloom-production --remote
+npx wrangler d1 execute dashloom-production --remote --command "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('workspaces','workspace_members','products','metric_points','analysis_runs','reports') ORDER BY name;"
+```
+
+The final migration list must show no pending entry and the critical tables must exist. A migration file in the repository is not proof that production was migrated.
+
+For Supabase, copy the database connection string from the intended project's database settings, set `SUPABASE_DATABASE_URL` only in your secure shell or CI secret store, then run:
 
 ```bash
 npm run db:migrate:supabase
@@ -65,3 +88,13 @@ npm run build:supabase
 ```
 
 Then verify sign-in, workspace language switching, one connector synchronization, one Agent run, and both authenticated cron endpoints against the selected backend.
+
+## Production checklist and rollback
+
+1. Confirm `BETTER_AUTH_URL` matches the final HTTPS origin and test sign-in and recovery.
+2. Create a workspace and verify that the selected `DASHLOOM_DEFAULT_LOCALE` is applied only to new workspaces.
+3. Run one connector synchronization and confirm evidence is stored in the selected backend.
+4. Call both Cron endpoints with the production `REPORT_CRON_SECRET` and inspect the automation ledger.
+5. Test export and one cited Agent run before announcing availability.
+
+Back up the selected database before a risky migration; see the [backup and recovery guide](backup-and-recovery.md). If application verification fails, roll the hosting deployment back to its previous version. Do not manually delete tables or edit migration history. Database rollback requires a tested backup or provider recovery mechanism, followed by migration and schema verification.

--- a/docs/deployment-next.zh-CN.md
+++ b/docs/deployment-next.zh-CN.md
@@ -8,6 +8,17 @@ Dashloom Community 现在有三条真实的运行路径：
 
 Cloudflare Workers、Vercel 和 AWS 是部署目标，不是业务数据源，因此不会出现在 Dashboard 的数据源目录中。
 
+如需使用原生 Worker 路径，请阅读 [Cloudflare 部署指南](deployment-cloudflare.zh-CN.md)。
+
+## 准备条件
+
+- Node.js 22.13 或更高版本、npm 10 或更高版本
+- Vercel 项目、AWS Amplify Hosting 应用或其他兼容 Node.js 的托管环境
+- 一个仅供 Community 使用的新 Remote D1 数据库或 Supabase 项目
+- 用于认证回调的公开 HTTPS Origin
+
+把仓库连接到托管平台前，先在本地运行 `npm ci` 和 `npm test`。
+
 ## 必需的环境变量
 
 把 `node-runtime.env.example` 中的变量配置到目标平台，并始终配置认证、凭据加密和 Cron Secret。然后只选择一种存储后端：
@@ -39,7 +50,19 @@ Cloudflare Workers 会按照 `wrangler.jsonc` 每 15 分钟执行一次 `worker.
 
 启动部署前，必须应用所选后端对应的 Migration；应用构建成功不代表生产数据库结构已经完成迁移。
 
-D1 使用 Wrangler，并验证目标远程数据库没有待应用 Migration。Supabase 则从数据库设置复制连接字符串，只在安全 Shell 或 CI Secret 中设置 `SUPABASE_DATABASE_URL`，然后运行：
+使用 D1 时，先确认生产数据库名称与 UUID，返回的 UUID 必须与 `CLOUDFLARE_D1_DATABASE_ID` 一致。检查 Migration 状态、应用仓库 Migration、重新检查，并查询同一个数据库中的关键表：
+
+```bash
+npx wrangler d1 info dashloom-production --json
+npx wrangler d1 migrations list dashloom-production --remote
+npx wrangler d1 migrations apply dashloom-production --remote
+npx wrangler d1 migrations list dashloom-production --remote
+npx wrangler d1 execute dashloom-production --remote --command "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('workspaces','workspace_members','products','metric_points','analysis_runs','reports') ORDER BY name;"
+```
+
+最终 Migration 列表必须没有待执行项，且关键表必须存在。仓库中存在 Migration 文件不代表生产数据库已经完成迁移。
+
+使用 Supabase 时，从目标项目的数据库设置复制连接字符串，只在安全 Shell 或 CI Secret 中设置 `SUPABASE_DATABASE_URL`，然后运行：
 
 ```bash
 npm run db:migrate:supabase
@@ -65,3 +88,13 @@ npm run build:supabase
 ```
 
 随后针对所选后端验证登录、工作空间语言切换、一次连接器同步、一次 Agent 运行，以及两个带认证的 Cron 接口。
+
+## 生产核验与回滚
+
+1. 确认 `BETTER_AUTH_URL` 与最终 HTTPS Origin 一致，并测试登录与找回流程。
+2. 创建工作空间，确认所选 `DASHLOOM_DEFAULT_LOCALE` 只应用于新工作空间。
+3. 完成一次连接器同步，并确认证据写入所选后端。
+4. 使用生产 `REPORT_CRON_SECRET` 调用两个 Cron 接口，并检查自动化台账。
+5. 对外宣布可用前测试导出和一次带证据引用的 Agent 运行。
+
+执行高风险 Migration 前先备份所选数据库，具体方式见[备份与恢复指南](backup-and-recovery.zh-CN.md)。如果应用核验失败，把托管部署回滚到上一版本。不要手动删除表或修改 Migration 历史。数据库回滚必须使用经过测试的备份或 Provider 恢复机制，并在恢复后重新执行 Migration 与 Schema 核验。


### PR DESCRIPTION
## Summary

- add complete English and Simplified Chinese Cloudflare deployment tutorials
- update the Vercel/AWS guide with deployment-language selection and production database verification
- correct README deployment links and add the Cloudflare guide to the documentation index

## Validation

- npm run docs:generate (45 articles generated)
- local Markdown links resolve
- npm run build:next

No production deployment or database migration was performed.